### PR TITLE
feat: Implement global stopwatch controls and event logging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import Stopwatch from './Stopwatch';
 import './App.css';
 
 function App() {
   const [lanes, setLanes] = useState([]);
   const [nextLaneId, setNextLaneId] = useState(1);
+  const stopwatchRefs = useRef({});
 
   const addLane = () => {
     setLanes([...lanes, { id: nextLaneId }]);
@@ -13,18 +14,62 @@ function App() {
 
   const closeLane = (laneId) => {
     setLanes(lanes.filter(lane => lane.id !== laneId));
+    delete stopwatchRefs.current[laneId];
+  };
+
+  const handleStopAll = () => {
+    Object.values(stopwatchRefs.current).forEach(ref => {
+      if (ref && typeof ref.stop === 'function') {
+        ref.stop();
+      } else {
+        console.error('Stopwatch ref does not have a stop method or is null.');
+      }
+    });
+  };
+
+  const handleResetAll = () => {
+    Object.values(stopwatchRefs.current).forEach(ref => {
+      if (ref && typeof ref.reset === 'function') {
+        ref.reset();
+      } else {
+        console.error('Stopwatch ref does not have a reset method or is null.');
+      }
+    });
+  };
+
+  const handleRestartAll = () => {
+    Object.values(stopwatchRefs.current).forEach(ref => {
+      if (ref) {
+        if (typeof ref.reset === 'function') {
+          ref.reset();
+        } else {
+          console.error('Stopwatch ref does not have a reset method.');
+        }
+        if (typeof ref.start === 'function') {
+          ref.start();
+        } else {
+          console.error('Stopwatch ref does not have a start method.');
+        }
+      } else {
+        console.error('Stopwatch ref is null.');
+      }
+    });
   };
 
   return (
     <div className="App">
       <h1>Multi-Lane Stopwatch</h1>
       <button onClick={addLane}>Add Lane</button>
+      <button onClick={handleStopAll}>Stop All</button>
+      <button onClick={handleResetAll}>Reset All</button>
+      <button onClick={handleRestartAll}>Restart All</button>
       <div className="lanes">
         {lanes.map((lane) => (
           <div key={lane.id}>
-            <Stopwatch 
-              lane={lane.id} 
-              onClose={() => closeLane(lane.id)} 
+            <Stopwatch
+              ref={(el) => stopwatchRefs.current[lane.id] = el}
+              lane={lane.id}
+              onClose={() => closeLane(lane.id)}
             />
           </div>
         ))}


### PR DESCRIPTION
This commit introduces two main enhancements to the multi-lane stopwatch:

1.  Global Controls:
    *   You can now control all active stopwatches simultaneously.
    *   Added "Stop All", "Reset All", and "Restart All" buttons.
    *   `App.jsx` now manages references to `Stopwatch` components to facilitate these global actions.

2.  Per-Lane Event Logging:
    *   Each stopwatch now records start, stop, and reset events.
    *   A timestamp is stored for each event. For "stop" events, the time on the stopwatch at the moment of stopping is also recorded.
    *   A "Show/Hide Log" button is available for each lane to view its specific event history.
    *   `Stopwatch.jsx` uses `forwardRef` and `useImperativeHandle` to expose control methods and manage its own log.

These changes improve the usability of the application for managing multiple timing lanes and provide a record of actions for each lane.